### PR TITLE
important notes on Romanian Protestant version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Repository of public domain and freely licensed bibles in XML and other standard
 | eng-web.usfx.xml               | English    | USFX    | World English Bible                   | Public Domain |
 | lat-clementine-vul.usfx.xml    | Latin      | USFX    | Clementine Latin Vulgate              | Public Domain |
 | por-almeida.usfx.xml           | Portuguese | USFX    | João Ferreira de Almeida              | Public Domain |
-| ron-rccv.usfx.xml              | Romanian   | USFX    | Romanian Corrected Cornilescu Version | Public Domain |
+| ron-rccv.usfx.xml              | Romanian   | USFX    | Protestant Romanian Corrected Cornilescu Version | Public Domain |
 | nl-statenvertaling.zefania.xml | Dutch      | Zefania | Statenvertaling (1637)                | Public Domain |
 
 ## How to Use


### PR DESCRIPTION
Romania is in its vast majority Orthodox. This bible translation is Protestant, therefor it should be properly mentioned. Resources: https://en.wikipedia.org/wiki/Dumitru_Cornilescu