### PR TITLE
add malaylam transilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Repository of public domain and freely licensed bibles in some standard XML form
 | heb-leningrad.usfx.xml          | Hebrew       | USFX    |        | Hebrew Leningrad Codex                            | _see below_   |
 | jpn-kougo.osis.xml              | Japanese     | OSIS    |        | Japanese Kougo (Colloquial)                       | Public Domain |
 | lat-clementine.usfx.xml         | Latin        | USFX    |        | Clementine Latin Vulgate                          | Public Domain |
+| mal-malsvp.zefania.xml          | Malayalam    | Zefania |        | Malayalam 1956 Transilation                       | Public Domain |
 | por-almeida.usfx.xml            | Portuguese   | USFX    |        | João Ferreira de Almeida                          | Public Domain |
 | ron-rccv.usfx.xml               | Romanian     | USFX    |        | Protestant Romanian Corrected Cornilescu Version  | Public Domain |
 | rus-synodal.zefania.xml         | Russian      | Zefania |        | Russian Synodal Translation                       | Public Domain |


### PR DESCRIPTION
IMPORTANT: when adding a new bible translation to this repo, please link to the source where you obtained the file. If it's not obvious from the linked source, please also link to the license for the bible translation so we can ensure it is available for distribution. Thanks!
This is the bible translation of 1956 in the Indian language Malayalam , Translation is popularly known as 'sathya vedha pusthakam' 
original source :https://github.com/godlytalias/Bible-Database
converted using : https://github.com/sojankreji/open-bible-converter